### PR TITLE
Turn on introspection for subgraphs

### DIFF
--- a/subgraphs/products/schema.graphql
+++ b/subgraphs/products/schema.graphql
@@ -56,7 +56,7 @@ type Product @key(fields: "id") @key(fields: "upc") @tag(name: "partner") {
   """
   Variants of the products to view specific size/color/price options
   """
-  variants(searchInput: VariantSearchInput): [Variant]
+  variants(searchInput: VariantSearchInput = {}): [Variant]
 }
 
 """

--- a/subgraphs/subgraphs.js
+++ b/subgraphs/subgraphs.js
@@ -64,6 +64,8 @@ export const startSubgraphs = async (httpPort) => {
     const schema = subgraphConfig.getSchema();
     const server = new ApolloServer({
       schema,
+      // For a real subgraph introspection should remain off, but for demo we enabled
+      introspection: true,
       plugins: [ApolloServerPluginDrainHttpServer({ httpServer })]
     });
 


### PR DESCRIPTION
For a real subgraph introspection should remain off, but for demo we enabled