### PR TITLE
Remove IDE plugin comments

### DIFF
--- a/subgraphs/checkout/schema.graphql
+++ b/subgraphs/checkout/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires"])
 

--- a/subgraphs/discovery/schema.graphql
+++ b/subgraphs/discovery/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
 

--- a/subgraphs/orders/schema.graphql
+++ b/subgraphs/orders/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
 

--- a/subgraphs/products/schema.graphql
+++ b/subgraphs/products/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@tag"])
 

--- a/subgraphs/reviews/schema.graphql
+++ b/subgraphs/reviews/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
 

--- a/subgraphs/shipping/schema.graphql
+++ b/subgraphs/shipping/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires"])
 

--- a/subgraphs/users/schema.graphql
+++ b/subgraphs/users/schema.graphql
@@ -1,5 +1,3 @@
-# noinspection GraphQLTypeRedefinition
-
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
 


### PR DESCRIPTION
Remove the header comments as they are not needed on the latest version of the GraphQL IntelliJ plugin.

This also updates the schema so we can deploy the latest Router