### PR TITLE
Update for docs quickstart

### DIFF
--- a/router-config-dev.yaml
+++ b/router-config-dev.yaml
@@ -1,6 +1,11 @@
 supergraph:
   listen: 127.0.0.1:4000
 
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
+
 headers:
   all:
     request:

--- a/subgraphs/checkout/data.js
+++ b/subgraphs/checkout/data.js
@@ -1,7 +1,7 @@
 export const activeCarts = [
   {
     userId: "user:1",
-    items: [{ id: "variant:1" }, { id: "variant:2" }],
+    items: [{ id: "variant:2" }, { id: "variant:5" }],
   },
   {
     userId: "user:2",

--- a/subgraphs/products/data.js
+++ b/subgraphs/products/data.js
@@ -50,6 +50,168 @@ export const PRODUCTS = [
     mediaUrl:
       "https://cdn.flightclub.com/750/TEMPLATE/317410/1.jpg",
   },
+  {
+    id: "product:6",
+    variants: [{ id: "variant:14" }],
+    title: "Yeezy Boost 350 V2",
+    description:
+      "Yeezy Boost 350 V2 is a popular sneaker from Kanye West's collaboration with Adidas, featuring a distinct stripe and innovative Primeknit material.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/801936/1.jpg",
+  },
+  {
+    id: "product:7",
+    variants: [{ id: "variant:15" }, { id: "variant:16" }],
+    title: "Nike Air Max 97",
+    description:
+      "Nike Air Max 97 features a sleek design with reflective lines and full-length Max Air cushioning.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803738/1.jpg",
+  },
+  {
+    id: "product:8",
+    variants: [{ id: "variant:17" }],
+    title: "Converse Chuck Taylor All Star",
+    description:
+      "The classic Converse Chuck Taylor All Star sneaker, known for its timeless design and versatility.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803681/1.jpg",
+  },
+  {
+    id: "product:9",
+    variants: [{ id: "variant:18" }, { id: "variant:19" }],
+    title: "Puma Suede Classic",
+    description:
+      "Puma Suede Classic is an iconic sneaker with a stylish suede upper and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803682/1.jpg",
+  },
+  {
+    id: "product:10",
+    variants: [{ id: "variant:20" }],
+    title: "Reebok Classic Leather",
+    description:
+      "Reebok Classic Leather is a timeless sneaker known for its sleek design and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803683/1.jpg",
+  },
+  {
+    id: "product:11",
+    variants: [{ id: "variant:21" }, { id: "variant:22" }],
+    title: "Vans Old Skool",
+    description:
+      "Vans Old Skool is a classic skate shoe featuring the iconic side stripe and durable canvas upper.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803684/1.jpg",
+  },
+  {
+    id: "product:12",
+    variants: [{ id: "variant:23" }],
+    title: "New Balance 574",
+    description:
+      "New Balance 574 is a versatile sneaker known for its retro style and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803685/1.jpg",
+  },
+  {
+    id: "product:13",
+    variants: [{ id: "variant:24" }, { id: "variant:25" }],
+    title: "Adidas Stan Smith",
+    description:
+      "Adidas Stan Smith is a classic tennis shoe featuring a clean design and premium leather upper.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803686/1.jpg",
+  },
+  {
+    id: "product:14",
+    variants: [{ id: "variant:26" }],
+    title: "Asics Gel-Lyte III",
+    description:
+      "Asics Gel-Lyte III is known for its split tongue design and comfortable gel cushioning.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803687/1.jpg",
+  },
+  {
+    id: "product:15",
+    variants: [{ id: "variant:27" }, { id: "variant:28" }],
+    title: "Saucony Jazz Original",
+    description:
+      "Saucony Jazz Original is a retro running shoe with a stylish design and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803688/1.jpg",
+  },
+  {
+    id: "product:16",
+    variants: [{ id: "variant:29" }],
+    title: "Fila Disruptor II",
+    description:
+      "Fila Disruptor II is a chunky sneaker with a bold design and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803689/1.jpg",
+  },
+  {
+    id: "product:17",
+    variants: [{ id: "variant:30" }, { id: "variant:31" }],
+    title: "Nike Blazer Mid '77",
+    description:
+      "Nike Blazer Mid '77 is a classic basketball sneaker with a retro design and versatile style.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803690/1.jpg",
+  },
+  {
+    id: "product:18",
+    variants: [{ id: "variant:32" }],
+    title: "Under Armour Curry 8",
+    description:
+      "Under Armour Curry 8 is a performance basketball shoe designed in collaboration with Stephen Curry.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803691/1.jpg",
+  },
+  {
+    id: "product:19",
+    variants: [{ id: "variant:33" }, { id: "variant:34" }],
+    title: "Hoka One One Clifton 7",
+    description:
+      "Hoka One One Clifton 7 is a highly cushioned running shoe designed for maximum comfort.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803692/1.jpg",
+  },
+  {
+    id: "product:20",
+    variants: [{ id: "variant:35" }],
+    title: "Brooks Ghost 13",
+    description:
+      "Brooks Ghost 13 is a versatile running shoe known for its smooth ride and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803693/1.jpg",
+  },
+  {
+    id: "product:21",
+    variants: [{ id: "variant:36" }, { id: "variant:37" }],
+    title: "Salomon Speedcross 5",
+    description:
+      "Salomon Speedcross 5 is a trail running shoe with aggressive traction and durable construction.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803694/1.jpg",
+  },
+  {
+    id: "product:22",
+    variants: [{ id: "variant:38" }],
+    title: "Merrell Moab 2 Ventilator",
+    description:
+      "Merrell Moab 2 Ventilator is a hiking shoe known for its breathable design and durable construction.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803695/1.jpg",
+  },
+  {
+    id: "product:23",
+    variants: [{ id: "variant:39" }, { id: "variant:40" }],
+    title: "Columbia Newton Ridge Plus II",
+    description:
+      "Columbia Newton Ridge Plus II is a waterproof hiking boot with a stylish design and comfortable fit.",
+    mediaUrl:
+      "https://cdn.flightclub.com/750/TEMPLATE/803696/1.jpg",
+  }
 ];
 
 export const VARIANTS = [
@@ -167,6 +329,249 @@ export const VARIANTS = [
     colorway: "Black and gold",
     price: 150,
     size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 10.0,
+  },
+  {
+    id: "variant:14",
+    product: { id: "product:6" },
+    colorway: "Zebra",
+    price: 220,
+    size: "9",
+    dimensions: "13inx10inx5in",
+    weight: 8.0,
+  },
+  {
+    id: "variant:15",
+    product: { id: "product:7" },
+    colorway: "Silver Bullet",
+    price: 180,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:16",
+    product: { id: "product:7" },
+    colorway: "Silver Bullet",
+    price: 180,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:17",
+    product: { id: "product:8" },
+    colorway: "Black",
+    price: 55,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 10.0,
+  },
+  {
+    id: "variant:18",
+    product: { id: "product:9" },
+    colorway: "Navy",
+    price: 70,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 11.0,
+  },
+  {
+    id: "variant:19",
+    product: { id: "product:9" },
+    colorway: "Navy",
+    price: 70,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 11.0,
+  },
+  {
+    id: "variant:20",
+    product: { id: "product:10" },
+    colorway: "White",
+    price: 75,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 11.0,
+  },
+  {
+    id: "variant:21",
+    product: { id: "product:11" },
+    colorway: "Black/White",
+    price: 60,
+    size: "8",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:22",
+    product: { id: "product:11" },
+    colorway: "Black/White",
+    price: 60,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:23",
+    product: { id: "product:12" },
+    colorway: "Grey",
+    price: 80,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.5,
+  },
+  {
+    id: "variant:24",
+    product: { id: "product:13" },
+    colorway: "White/Green",
+    price: 85,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:25",
+    product: { id: "product:13" },
+    colorway: "White/Green",
+    price: 85,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:26",
+    product: { id: "product:14" },
+    colorway: "Mint",
+    price: 110,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:27",
+    product: { id: "product:15" },
+    colorway: "Blue",
+    price: 75,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:28",
+    product: { id: "product:15" },
+    colorway: "Blue",
+    price: 75,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:29",
+    product: { id: "product:16" },
+    colorway: "White",
+    price: 65,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 10.0,
+  },
+  {
+    id: "variant:30",
+    product: { id: "product:17" },
+    colorway: "White",
+    price: 100,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:31",
+    product: { id: "product:17" },
+    colorway: "White",
+    price: 100,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:32",
+    product: { id: "product:18" },
+    colorway: "Royal",
+    price: 130,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:33",
+    product: { id: "product:19" },
+    colorway: "Maroon",
+    price: 140,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.5,
+  },
+  {
+    id: "variant:34",
+    product: { id: "product:20" },
+    colorway: "Green",
+    price: 150,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.5,
+  },
+  {
+    id: "variant:35",
+    product: { id: "product:21" },
+    colorway: "Black",
+    price: 160,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 10.0,
+  },
+  {
+    id: "variant:36",
+    product: { id: "product:22" },
+    colorway: "Grey",
+    price: 170,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:37",
+    product: { id: "product:23" },
+    colorway: "Brown",
+    price: 180,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.5,
+  },
+  {
+    id: "variant:38",
+    product: { id: "product:24" },
+    colorway: "Wheat",
+    price: 190,
+    size: "9",
+    dimensions: "12inx10inx6in",
+    weight: 9.0,
+  },
+  {
+    id: "variant:39",
+    product: { id: "product:25" },
+    colorway: "Black",
+    price: 200,
+    size: "10",
+    dimensions: "12inx10inx6in",
+    weight: 10.0,
+  },
+  {
+    id: "variant:40",
+    product: { id: "product:25" },
+    colorway: "Black",
+    price: 200,
+    size: "11",
     dimensions: "12inx10inx6in",
     weight: 10.0,
   },

--- a/subgraphs/products/resolvers.js
+++ b/subgraphs/products/resolvers.js
@@ -7,6 +7,9 @@ export const resolvers = {
   Query: {
     product: (_, { id }) => getProductById(id),
     variant: (_, { id }) => getVariantById(id),
+    listAllProducts() {
+      return PRODUCTS;
+    },
     searchVariants(_, { searchInput }) {
       if (searchInput?.sizeStartsWith) {
         return VARIANTS.filter((v) =>

--- a/subgraphs/products/schema.graphql
+++ b/subgraphs/products/schema.graphql
@@ -3,6 +3,11 @@ extend schema
 
 type Query {
   """
+  List all available products without any search filters
+  """
+  listAllProducts: [Product]
+  
+  """
   Get all available products to shop for. Optionally provide some search filters
   """
   searchProducts(searchInput: ProductSearchInput! = {}): [Product]

--- a/subgraphs/subgraphs.js
+++ b/subgraphs/subgraphs.js
@@ -1,6 +1,8 @@
 import { expressMiddleware } from '@apollo/server/express4';
 import { ApolloServer } from '@apollo/server';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
+import { ApolloServerPluginInlineTraceDisabled } from '@apollo/server/plugin/disabled';
+
 import express from 'express';
 import http from 'http';
 import cors from 'cors';
@@ -66,7 +68,7 @@ export const startSubgraphs = async (httpPort) => {
       schema,
       // For a real subgraph introspection should remain off, but for demo we enabled
       introspection: true,
-      plugins: [ApolloServerPluginDrainHttpServer({ httpServer })]
+      plugins: [ApolloServerPluginDrainHttpServer({ httpServer }), ApolloServerPluginInlineTraceDisabled()]
     });
 
     await server.start();


### PR DESCRIPTION
As part of the improved onboarding experience initiative, we're updating our Federation quickstart to be Rover based. See  https://github.com/apollographql/federation/pull/3037.

The quickstart uses this demo supergraph and we'd like to:

- Remove distracting warnings from the console (i.e. about tracing and telemetry)
- Add an example query that doesn't require any variables or header inputs (`listAllProducts`)
- Add a richer dataset.